### PR TITLE
fix: babel env targets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
   "presets": [
-    ["env", { "browsers": ["last 2 versions"] }]
+    [
+      "env",
+      {
+        "targets": {
+          "browsers": [">0.25%", "not ie 11", "not op_mini all"]
+        }
+      }
+    ]
   ]
 }


### PR DESCRIPTION
The babel config was incorrect firstly, secondly change the config so babel doesn't compile away arrow functions forever. See https://jamie.build/last-2-versions